### PR TITLE
Add unique temp files name

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "babel-preset-stage-3": "^6.11.0"
   },
   "dependencies": {
-    "babel-runtime": "^6.20.0"
+    "babel-runtime": "^6.20.0",
+    "uuid": "^8.3.2"
   }
 }

--- a/src/polyfill/assign-json.js
+++ b/src/polyfill/assign-json.js
@@ -1,5 +1,6 @@
 const fs = require('../util/fs');
 const path = require('path');
+const uuid = require('uuid');
 
 const escapeSymbol = (str) => {
   return str.replace(/((\#\{)|(\@\{)|(\$\{))([^}]*)\}?/g, function (...args) {
@@ -22,9 +23,9 @@ function reduceMockTpl (mockData, tpl, tagSyntax) {
 }
 
 export async function createTmp (p1, data, tagSyntax) {
-  return new Promise(async (resolve, reject) => {
+  return new Promise(async (resolve, _reject) => {
     const {name, dir} = path.parse(p1);
-    const _tempPath = path.join(dir, '__temp__' + name + '.ftl');
+    const _tempPath = path.join(dir, `${uuid.v4()}__${name}.ftl`);
     let _tpl = reduceMockTpl(data, null, tagSyntax);
     const lines = _tpl.length;
     try{


### PR DESCRIPTION
To avoid premature deleting the temp file when running multiple render processes (For example [parallel-transform](https://github.com/mafintosh/parallel-transform)), added the generation of a unique name for temp files